### PR TITLE
SteeringMotor{} rewrite

### DIFF
--- a/examples/motor/m3508_steering.cc
+++ b/examples/motor/m3508_steering.cc
@@ -45,11 +45,9 @@ bsp::GPIO* key = nullptr;
 
 BoolEdgeDetector key_detector(false);
 
+// temporal alignment sensor for testing
 bool steering_align_detect() {
-  // float theta = wrap<float>(steering->GetRawTheta(), 0, 2 * PI);
-  // return abs(theta - 3) < 0.05;
   return key->Read() == 1;
-  // return true;
 }
 
 void RM_RTOS_Init() {
@@ -60,7 +58,13 @@ void RM_RTOS_Init() {
   motor1 = new control::Motor3508(can1, 0x201);
   motor3 = new control::Motor3508(can1, 0x203);
 
-  // The 'key' is the white button on TypeA boards
+  /* Usage:
+   *   The 'key' is the white button on TypeA boards
+   *   Press key to start alignment and then press key again to finish alignment.
+   *   Now the align angle is recorded:
+   *   Press key once will turn the motors to an angle.
+   *   Press key again will turn them to the align angle.
+  **/
   key = new bsp::GPIO(KEY_GPIO_GROUP, KEY_GPIO_PIN);
 
   control::steering_t steering_data;

--- a/examples/motor/m3508_steering.cc
+++ b/examples/motor/m3508_steering.cc
@@ -69,8 +69,8 @@ void RM_RTOS_Init() {
   steering_data.max_iout = 1000;
   steering_data.max_out = 13000;
   steering_data.align_detect_func = steering_align_detect;
-  //steering_data.calibrate_offset = 0;
-  steering_data.calibrate_offset = PI/2;
+  steering_data.calibrate_offset = 0;
+  //steering_data.calibrate_offset = PI/2;
   steering = new control::SteeringMotor(steering_data);
 }
 
@@ -104,12 +104,22 @@ void RM_RTOS_Default_Task(const void* args) {
 
   print("\r\nOK!\r\n");
 
+  int dir = 1;
+
   while (true) {
     key_detector.input(key->Read());
     if (key_detector.posEdge()){
-      steering->TurnRelative(PI * 0.25);
-      steering->PrintData();
+      if (dir == 1) {
+        // Motor should turn the give angle
+        steering->TurnRelative(PI * 4 + PI / 4);
+        steering->PrintData();
+      } else {
+        // Motor should go to align angle
+        steering->AlignUpdate();
+      }
+      dir *= -1;
     }
+
     steering->CalcOutput();
     control::MotorCANBase::TransmitOutput(motors, 1);
     osDelay(2);

--- a/examples/motor/m3508_steering.cc
+++ b/examples/motor/m3508_steering.cc
@@ -60,6 +60,7 @@ void RM_RTOS_Init() {
   motor1 = new control::Motor3508(can1, 0x201);
   motor3 = new control::Motor3508(can1, 0x203);
 
+  // The 'key' is the white button on TypeA boards
   key = new bsp::GPIO(KEY_GPIO_GROUP, KEY_GPIO_PIN);
 
   control::steering_t steering_data;

--- a/shared/libraries/motor.cc
+++ b/shared/libraries/motor.cc
@@ -462,22 +462,24 @@ void SteeringMotor::TurnRelative(float angle) {
   servo_->SetTarget(servo_->GetTarget() + angle, true);
 }
 
-void SteeringMotor::TurnAbsolute(float angle) { servo_->SetTarget(angle); }
-
 bool SteeringMotor::AlignUpdate() {
   if (align_complete_) {
+    // if calibration complete, go to aligned location
     servo_->SetTarget(align_angle_, true);
     servo_->CalcOutput();
     return true;
   } else if (align_detect_func()) {
+    // if calibration sensor True, stop
+    // record align_angle for next alignment
     float current_theta = servo_->motor_->GetTheta();
     float offset = wrap<float>(servo_->align_angle_ - current_theta, -PI, PI);
     float current = (current_theta + offset - servo_->align_angle_) / servo_->transmission_ratio_ +
                     servo_->offset_angle_ + servo_->cumulated_angle_;
     align_angle_ = current + calibrate_offset;
-    align_complete_ = true;
     servo_->SetTarget(align_angle_, true);
     servo_->CalcOutput();
+    // mark alignment as completed
+    align_complete_ = true;
     return true;
   } else {
     servo_->motor_->SetOutput(servo_->omega_pid_.ComputeConstrainedOutput(

--- a/shared/libraries/motor.cc
+++ b/shared/libraries/motor.cc
@@ -486,20 +486,21 @@ int SteeringMotor::TurnRelative(float angle, bool override) {
 
 bool SteeringMotor::AlignUpdate() {
   if (align_complete_) {
+    // erase previous target
+    servo_->SetTarget(servo_->GetTheta(), true);
     // if calibration complete, go to aligned location
-    servo_->SetTarget(align_angle_, true);
-    servo_->CalcOutput();
+    TurnRelative(align_angle_ - servo_->GetTheta(relative_mode));
+    CalcOutput();
     return true;
   } else if (align_detect_func()) {
     // if calibration sensor True, move an offset and stop.
     servo_->SetTarget(servo_->GetTheta() + calibrate_offset, true);
     servo_->CalcOutput();
     // mark alignment as complete and keep align_angle for next alignment
-    align_angle_ = servo_->GetTheta() + calibrate_offset;
+    align_angle_ = servo_->GetTheta(relative_mode) + calibrate_offset;
     align_complete_ = true;
 
     current_target_ = servo_->GetTarget();
-    print("%10.4f ", current_target_);
     return true;
   } else {
     // rotate slowly with TEST_SPEED, try to hit the calibration sensor

--- a/shared/libraries/motor.cc
+++ b/shared/libraries/motor.cc
@@ -272,7 +272,6 @@ ServoMotor::ServoMotor(servo_t data, float align_angle, float proximity_in, floa
   target_angle_ = 0;
   align_angle_ = align_angle;  // Wait for Update to initialize
   motor_angle_ = 0;
-  offset_angle_ = 0;
   servo_angle_ = 0;
   cumulated_angle_ = 0;
   inner_wrap_detector_ = new FloatEdgeDetector(0, PI);
@@ -392,7 +391,18 @@ void ServoMotor::PrintData() const {
   motor_->PrintData();
 }
 
-float ServoMotor::GetTheta() const { return servo_angle_ + cumulated_angle_; }
+float ServoMotor::GetTheta(GetThetaMode mode) const {
+  switch (mode) {
+    case absolute_mode:
+      return servo_angle_ + cumulated_angle_;
+      break;
+    case relative_mode:
+      return servo_angle_;
+      break;
+    default:
+      return servo_angle_ + cumulated_angle_;
+  }
+}
 
 float ServoMotor::GetThetaDelta(const float target) const { return target - GetTheta(); }
 
@@ -441,7 +451,7 @@ SteeringMotor::SteeringMotor(steering_t data) {
   servo_data.omega_pid_param = data.omega_pid_param;
   servo_data.max_iout = data.max_iout;
   servo_data.max_out = data.max_out;
-  servo_ = new ServoMotor(servo_data, data.offset_angle);
+  servo_ = new ServoMotor(servo_data);
 
   test_speed_ = data.test_speed;
   align_detect_func = data.align_detect_func;
@@ -449,17 +459,29 @@ SteeringMotor::SteeringMotor(steering_t data) {
   align_angle_ = 0;
   align_detector = new BoolEdgeDetector(false);
   align_complete_ = false;
+  current_target_ = 0;
 }
 
-float SteeringMotor::GetRawTheta() const { return servo_->GetTheta(); }
+float SteeringMotor::GetTheta(GetThetaMode mode) const {
+  return servo_->GetTheta(mode);
+}
 
 void SteeringMotor::PrintData() const {
-  print("Str-align: %10.5f ", align_angle_);
-  servo_->PrintData();
+  print("current_target: %10.4f ", current_target_);
+  print("current_theta: %10.4f ", this->GetTheta(relative_mode));
+  print("align_angle: %10.4f \r\n", align_angle_);
 }
 
-void SteeringMotor::TurnRelative(float angle) {
-  servo_->SetTarget(servo_->GetTarget() + angle, true);
+int SteeringMotor::TurnRelative(float angle, bool override) {
+  int servo_status = servo_->SetTarget(current_target_ + angle, override);
+
+  // if servo motor rejects (not holding), don't update the current_target
+  if (servo_status == INPUT_REJECT) {
+    return 1;
+  } else {
+    current_target_ += angle;
+    return 0;
+  }
 }
 
 bool SteeringMotor::AlignUpdate() {
@@ -469,25 +491,30 @@ bool SteeringMotor::AlignUpdate() {
     servo_->CalcOutput();
     return true;
   } else if (align_detect_func()) {
-    // if calibration sensor True, stop
-    // record align_angle for next alignment
-    float current_theta = servo_->motor_->GetTheta();
-    float offset = wrap<float>(servo_->align_angle_ - current_theta, -PI, PI);
-    float current = (current_theta + offset - servo_->align_angle_) / servo_->transmission_ratio_ +
-                    servo_->offset_angle_ + servo_->cumulated_angle_;
-    align_angle_ = current + calibrate_offset;
-    servo_->SetTarget(align_angle_, true);
+    // if calibration sensor True, move an offset and stop.
+    servo_->SetTarget(servo_->GetTheta() + calibrate_offset, true);
     servo_->CalcOutput();
-    // mark alignment as completed
+    // mark alignment as complete and keep align_angle for next alignment
+    align_angle_ = servo_->GetTheta() + calibrate_offset;
     align_complete_ = true;
+
+    current_target_ = servo_->GetTarget();
+    print("%10.4f ", current_target_);
     return true;
   } else {
+    // rotate slowly with TEST_SPEED, try to hit the calibration sensor
     servo_->motor_->SetOutput(servo_->omega_pid_.ComputeConstrainedOutput(
         servo_->motor_->GetOmegaDelta(test_speed_ * servo_->transmission_ratio_)));
   }
   return false;
 }
 
-void SteeringMotor::Update() { servo_->CalcOutput(); }
+void SteeringMotor::CalcOutput() {
+  servo_->CalcOutput();
+}
+
+void SteeringMotor::UpdateData(const uint8_t data[]) {
+  servo_->UpdateData(data);
+}
 
 } /* namespace control */

--- a/shared/libraries/motor.h
+++ b/shared/libraries/motor.h
@@ -505,8 +505,8 @@ typedef bool (*align_detect_t)(void);
  */
 typedef struct {
   MotorCANBase* motor;              /* motor instance to be wrapped as a servomotor       */
-  float max_speed;                  /* desired turning speed of motor shaft, in [rad/s]   */
-  float test_speed;                 /* speed used during calibration (alignment) [no unit]*/
+  float run_speed;                  /* normal turning speed of motor shaft, in [rad/s]    */
+  float test_speed;                 /* speed of motor shaft during alignment [rad/s]      */
   float max_acceleration;           /* desired acceleration of motor shaft, in [rad/s^2]  */
   float transmission_ratio;         /* transmission ratio of motor                        */
   float* omega_pid_param;           /* pid parameter used to control speed of motor       */
@@ -562,19 +562,11 @@ class SteeringMotor {
    */
   void UpdateData(const uint8_t data[]);
 
-  /**
-   * @brief keep the motor running with test_speed
-   * @note directly drives underlying motor, no need to call CalcOutput()
-   *       will update GetTheta() reads.
-   *
-   * @param test_speed, running speed in [rad / s]
-   */
-  void TestRun(float test_speed);
-
  private:
   ServoMotor* servo_;
 
   float test_speed_;                /* speed used during alignment (calibration)                                            */
+  float run_speed_;                 /* speed used after alignment                                                           */
   align_detect_t align_detect_func; /* function pointer for the calibration sensor, see comments for align_detect_t typedef */
   float calibrate_offset_;          /* difference between calibration sensor and desired starting position                  */
   float current_target_;            /* current absolute position in [rad] to drive the underlying servo motor               */
@@ -582,7 +574,6 @@ class SteeringMotor {
   float align_angle_;               /* store calibration angle                                                              */
   BoolEdgeDetector* align_detector;
   bool align_complete_;             /* if calibration is previously done, use the align_angle_                              */
-  bool mute_calcoutput_;            /* if true, CalcOutput() will be a dummy function. Use this to drive CANmotor directly  */
 };
 
 } /* namespace control */

--- a/shared/libraries/motor.h
+++ b/shared/libraries/motor.h
@@ -458,6 +458,16 @@ class ServoMotor {
    */
   void UpdateData(const uint8_t data[]);
 
+
+  /**
+   * @brief keep the ServoMotor running with test_speed
+   * @note directly drives underlying motor, no need to call CalcOutput()
+   *       will update GetTheta() reads.
+   *
+   * @param test_speed, running speed in [rad / s]
+   */
+  void TestRun(float test_speed);
+
   friend class SteeringMotor;
 
  private:
@@ -543,6 +553,8 @@ class SteeringMotor {
 
   /**
    * @brief Align the motor to its calibration position
+   *        If the motor doesn't have a alignment position, it tries to find one.
+   *        If the motor has one, it turns to it.
    * @return True when the motor has a calibration position
    */
   bool AlignUpdate();
@@ -559,6 +571,16 @@ class SteeringMotor {
    * @param data[]  raw data bytes
    */
   void UpdateData(const uint8_t data[]);
+
+  /**
+   * @brief keep the SteeringMotor running with test_speed
+   * @note directly drives underlying motor, no need to call CalcOutput()
+   *       will update GetTheta() reads.
+   *
+   * @param test_speed, running speed in [rad / s]
+   *        if no args or 0 given, will use private member test_speed_
+   */
+  void TestRun(float test_speed = 0);
 
  private:
   ServoMotor* servo_;

--- a/shared/libraries/motor.h
+++ b/shared/libraries/motor.h
@@ -487,25 +487,27 @@ class ServoMotor {
   BoolEdgeDetector* jam_detector_;  /* detect motor jam toggling, call jam callback accordingly */
 };
 
+// function pointer for the calibration function of the steering motor, return True when calibrated
 typedef bool (*align_detect_t)(void);
 
 /**
  * @brief structure used when steering motor instance is initialized
  */
 typedef struct {
-  MotorCANBase* motor; /* motor instance to be wrapped as a servomotor      */
-  float max_speed;     /* desired turning speed of motor shaft, in [rad/s]  */
+  MotorCANBase* motor;              /* motor instance to be wrapped as a servomotor       */
+  float max_speed;                  /* desired turning speed of motor shaft, in [rad/s]   */
   float test_speed;
-  float max_acceleration;   /* desired acceleration of motor shaft, in [rad/s^2] */
-  float transmission_ratio; /* transmission ratio of motor                       */
+  float max_acceleration;           /* desired acceleration of motor shaft, in [rad/s^2]  */
+  float transmission_ratio;         /* transmission ratio of motor                        */
   float offset_angle;
-  float* omega_pid_param; /* pid parameter used to control speed of motor      */
+  float* omega_pid_param;           /* pid parameter used to control speed of motor       */
   float max_iout;
   float max_out;
-  align_detect_t align_detect_func;
-  float calibrate_offset;
+  align_detect_t align_detect_func; /* function pointer for calibration function          */
+  float calibrate_offset = 0.0;     /* angle from calibration sensor to starting location */
 } steering_t;
 
+// mode that can turn relative angles in [rad]
 class SteeringMotor {
  public:
   SteeringMotor(steering_t data);
@@ -514,9 +516,22 @@ class SteeringMotor {
    * @brief print out motor data
    */
   void PrintData() const;
+
+  /**
+   * @brief Set the target to a relative angle in [rad]
+   */
   void TurnRelative(float angle);
-  void TurnAbsolute(float angle);
+
+  /**
+   * @brief Align the motor to its calibration position
+   * @return True when the motor is in calibration position
+   */
   bool AlignUpdate();
+
+  /**
+   * @brief calculate the output of the motors under current configuration
+   * Should be the same as CalcOutput()
+   */
   void Update();
 
  private:

--- a/shared/libraries/motor.h
+++ b/shared/libraries/motor.h
@@ -458,16 +458,6 @@ class ServoMotor {
    */
   void UpdateData(const uint8_t data[]);
 
-
-  /**
-   * @brief keep the ServoMotor running with test_speed
-   * @note directly drives underlying motor, no need to call CalcOutput()
-   *       will update GetTheta() reads.
-   *
-   * @param test_speed, running speed in [rad / s]
-   */
-  void TestRun(float test_speed);
-
   friend class SteeringMotor;
 
  private:
@@ -573,26 +563,26 @@ class SteeringMotor {
   void UpdateData(const uint8_t data[]);
 
   /**
-   * @brief keep the SteeringMotor running with test_speed
+   * @brief keep the motor running with test_speed
    * @note directly drives underlying motor, no need to call CalcOutput()
    *       will update GetTheta() reads.
    *
    * @param test_speed, running speed in [rad / s]
-   *        if no args or 0 given, will use private member test_speed_
    */
-  void TestRun(float test_speed = 0);
+  void TestRun(float test_speed);
 
  private:
   ServoMotor* servo_;
 
   float test_speed_;                /* speed used during alignment (calibration)                                            */
   align_detect_t align_detect_func; /* function pointer for the calibration sensor, see comments for align_detect_t typedef */
-  float calibrate_offset;           /* difference between calibration sensor and desired starting position                  */
+  float calibrate_offset_;          /* difference between calibration sensor and desired starting position                  */
   float current_target_;            /* current absolute position in [rad] to drive the underlying servo motor               */
 
   float align_angle_;               /* store calibration angle                                                              */
   BoolEdgeDetector* align_detector;
   bool align_complete_;             /* if calibration is previously done, use the align_angle_                              */
+  bool mute_calcoutput_;            /* if true, CalcOutput() will be a dummy function. Use this to drive CANmotor directly  */
 };
 
 } /* namespace control */

--- a/shared/libraries/steering.cc
+++ b/shared/libraries/steering.cc
@@ -43,7 +43,7 @@ SteeringChassis::SteeringChassis(steering_chassis_t* _chassis) {
   steering_data.max_speed = SPEED;
   steering_data.test_speed = TEST_SPEED;
   steering_data.max_acceleration = ACCELERATION;
-  steering_data.transmission_ratio = 8;
+  steering_data.transmission_ratio = M3508P19_RATIO;
   steering_data.omega_pid_param = new float[3]{140, 1.2, 25};
   steering_data.max_iout = 3000;
   steering_data.max_out = 13000;

--- a/shared/libraries/steering.cc
+++ b/shared/libraries/steering.cc
@@ -40,7 +40,7 @@ SteeringChassis::SteeringChassis(steering_chassis_t* _chassis) {
   // Init Steering Motors from CANBaseMotor
   control::steering_t steering_data;
 
-  steering_data.max_speed = SPEED;
+  steering_data.run_speed = SPEED;
   steering_data.test_speed = TEST_SPEED;
   steering_data.max_acceleration = ACCELERATION;
   steering_data.transmission_ratio = M3508P19_RATIO;

--- a/shared/libraries/steering.cc
+++ b/shared/libraries/steering.cc
@@ -48,28 +48,28 @@ SteeringChassis::SteeringChassis(steering_chassis_t* _chassis) {
   steering_data.max_iout = 3000;
   steering_data.max_out = 13000;
 
-  steering_data.offset_angle = -1;
+
   steering_data.motor = _chassis->fl_steer_motor;
   steering_data.align_detect_func = _chassis->fl_steer_motor_detect_func;
   // steering_data.calibrate_offset = -0.858458848;
   steering_data.calibrate_offset = 0;
   fl_steer_motor = new control::SteeringMotor(steering_data);
 
-  steering_data.offset_angle = -1;
+
   steering_data.motor = _chassis->fr_steer_motor;
   steering_data.align_detect_func = _chassis->fr_steer_motor_detect_func;
   // steering_data.calibrate_offset = 0.858458848;
   steering_data.calibrate_offset = 0;
   fr_steer_motor = new control::SteeringMotor(steering_data);
 
-  steering_data.offset_angle = -1;
+
   steering_data.motor = _chassis->bl_steer_motor;
   steering_data.align_detect_func = _chassis->bl_steer_motor_detect_func;
   // steering_data.calibrate_offset = -2.283133461;
   steering_data.calibrate_offset = 0;
   bl_steer_motor = new control::SteeringMotor(steering_data);
 
-  steering_data.offset_angle = -1;
+
   steering_data.motor = _chassis->br_steer_motor;
   steering_data.align_detect_func = _chassis->br_steer_motor_detect_func;
   // steering_data.calibrate_offset = 2.283133461;
@@ -89,10 +89,10 @@ SteeringChassis::SteeringChassis(steering_chassis_t* _chassis) {
   bl_steer_motor->TurnRelative(0.0);
   br_steer_motor->TurnRelative(0.0);
 
-  fl_steer_motor->Update();
-  fr_steer_motor->Update();
-  bl_steer_motor->Update();
-  br_steer_motor->Update();
+  fl_steer_motor->CalcOutput();
+  fr_steer_motor->CalcOutput();
+  bl_steer_motor->CalcOutput();
+  br_steer_motor->CalcOutput();
 
   fl_wheel_motor->SetOutput(0.0);
   fr_wheel_motor->SetOutput(0.0);
@@ -181,10 +181,10 @@ void SteeringChassis::Update(float _power_limit, float _chassis_power,
   bl_steer_motor->TurnRelative(theta2_diff);
   br_steer_motor->TurnRelative(theta3_diff);
 
-  fl_steer_motor->Update();
-  fr_steer_motor->Update();
-  bl_steer_motor->Update();
-  br_steer_motor->Update();
+  fl_steer_motor->CalcOutput();
+  fr_steer_motor->CalcOutput();
+  bl_steer_motor->CalcOutput();
+  br_steer_motor->CalcOutput();
 
   // compute speed for wheel motors
   float v0 = sqrt(pow(vy + vw * cos(PI / 4), 2.0) + pow(vx - vw * sin(PI / 4), 2.0));


### PR DESCRIPTION
- Rewrite `AlignUpdate()`
- Improve `TurnRelative()` `GetTheta()` implementation
- Change a few function names
- Remove / Add some private members
- Change downstream libraries accordingly
- Add example for 2 motors alignment (calibration) in `m3508_steering.cc`