### PR TITLE
Remove check-format from github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,10 +32,6 @@ jobs:
       run: |
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Debug ..
-    # format check temporarily commented
-    - name: format check
-      run: make check-format
-      working-directory: build
     - name: build
       run: make -j
       working-directory: build


### PR DESCRIPTION
Even if we run `make format` locally, github seems to use a different version of clang-format and insists that more formats must be made. Therefore we remove the check-format from the github workflow.