### PR TITLE
Finished STM32->Jetson Communication; now the communication is bidirectional

### DIFF
--- a/examples/minipc/typeC.cc
+++ b/examples/minipc/typeC.cc
@@ -73,9 +73,6 @@ void RM_RTOS_Default_Task(const void* argument) {
       length = uart->Read(&data);
       total_processed_bytes += length;
 
-      // if read anything, flash red
-      led->Display(0xFFFF0000);
-
       miniPCreceiver.Receive(data, length);
       uint32_t valid_packet_cnt = miniPCreceiver.get_valid_packet_cnt();
 
@@ -97,10 +94,12 @@ void RM_RTOS_Default_Task(const void* argument) {
           }
           miniPCreceiver.Send(&packet_to_send, my_color);
           uart->Write((uint8_t*)&packet_to_send, sizeof(communication::STMToJetsonData));
+          osDelay(1);
         }
       }
       // blue when nothing is received
       led->Display(0xFF0000FF);
     }
+    osDelay(1);
   }
 }

--- a/examples/minipc/typeC.cc
+++ b/examples/minipc/typeC.cc
@@ -82,10 +82,22 @@ void RM_RTOS_Default_Task(const void* argument) {
       // Jetson / PC sends 200Hz valid packets for stress testing
       // For testing script, please see iRM_Vision_2023/Communication/communicator.py
       // For comm protocol details, please see iRM_Vision_2023/docs/comm_protocol.md
-      if (valid_packet_cnt > 998) {
-        // If at least 99.9% packets are valid, pass
+      if (valid_packet_cnt == 1000) {
+        // Jetson test cases write 1000 packets. Pass
         led->Display(0xFF00FF00);
         osDelay(10000);
+        // after 10 seconds, write 1000 alternating packets to Jetson
+        communication::STMToJetsonData packet_to_send;
+        uint8_t my_color = 1; // blue
+        for (int i = 0; i < 1000; ++i) {
+          if (i % 2 == 0) {
+            my_color = 1; // blue
+          } else {
+            my_color = 0; // red
+          }
+          miniPCreceiver.Send(&packet_to_send, my_color);
+          uart->Write((uint8_t*)&packet_to_send, sizeof(communication::STMToJetsonData));
+        }
       }
       // blue when nothing is received
       led->Display(0xFF0000FF);

--- a/shared/libraries/minipc.cc
+++ b/shared/libraries/minipc.cc
@@ -62,7 +62,6 @@ void MiniPCProtocol::Receive(const uint8_t* data, uint8_t length) {
       // Case 3
       // done package reading
       index = 0;
-      // package handling here!TODO:
       handle();
     } else {
       if (remain == length) {
@@ -77,7 +76,7 @@ void MiniPCProtocol::Receive(const uint8_t* data, uint8_t length) {
   while (i < (int)length) {
     if (index == 0) {
       if (i == (int)length - 1) {
-        // Handle the last byte; index must be zero
+        // A special case to handle the last byte; index must be zero
         if (data[i] == 'S' || data[i] == 'M') {
           host_command[index++] = data[i];
         }
@@ -105,6 +104,21 @@ void MiniPCProtocol::handle(void) {
   // TODO: implement thread-safe logic here (use a lock to handle changes from interrupt)
   // here we can assume that the package is complete
   // in the host_command buffer
+
+  // TODO: add a logic here such that when the checking fails; it moves the write pointer 'index'
+  // to the next 'S' or 'M' for more robustness.
+  // A minor issue with current implementation: imagine the following case:
+  //  Two packets arrive in two UART calls.
+  //  The first packet misses 1 byte, but the second one is complete.
+  //  In this case, when the host_command buffer is filled
+  //  (the last byte is 'S' or 'M' for the second packet), handle() will be called. The whole buffer
+  //  would be tossed, resulting in two unusable packets. However, if we implement this logic, we would be
+  //  able to recover the second packet.
+
+  // This is a minor issue because
+  //    1) we don't observe this even when packets are sent at 200Hz
+  //    2) probability of this happening is very low. The second packet has to be sent in two slices to
+  //       trigger this issue. (first slice: S/T is sent to host_command; second slide: the rest)
 
   // check end of packet is 'ED'
   if (host_command[PKG_LEN - 2] != 'E' || host_command[PKG_LEN - 1] != 'D') {

--- a/shared/libraries/minipc.cc
+++ b/shared/libraries/minipc.cc
@@ -30,6 +30,20 @@ MiniPCProtocol::MiniPCProtocol() {
   flag = 0;
 }
 
+void MiniPCProtocol::Send(STMToJetsonData* packet, uint8_t color) {
+  packet->header[0] = 'H';
+  packet->header[1] = 'D';
+  packet->my_color = color;
+
+  const int tail_offset = 3; // size of data minus uint8_t checksum and 2 uint8_t tail
+  packet->crc8_checksum = get_crc8_check_sum((uint8_t*)packet,
+                                              sizeof(STMToJetsonData) - tail_offset,
+                                              0);
+
+  packet->tail[0] = 'E';
+  packet->tail[1] = 'D';
+}
+
 void MiniPCProtocol::Receive(const uint8_t* data, uint8_t length) {
   // Four cases
   // Case 1: everything is fresh with complete package(s)

--- a/shared/libraries/minipc.h
+++ b/shared/libraries/minipc.h
@@ -27,6 +27,13 @@
 
 namespace communication {
 
+struct STMToJetsonData {
+  char header[2];
+  uint8_t my_color; // RED is 0; BLUE is one
+  uint8_t crc8_checksum;
+  char tail[2];
+};
+
 // WARNING: THIS CLASS IS NOT THREAD SAFE!!!
 
 class MiniPCProtocol {
@@ -34,7 +41,7 @@ class MiniPCProtocol {
   MiniPCProtocol();
   void Receive(const uint8_t* data, uint8_t len);
   // dummy send
-  void Send();
+  void Send(STMToJetsonData* packet, uint8_t color);
   uint8_t get_valid_flag(void);
   float get_relative_yaw(void);
   float get_relative_pitch(void);


### PR DESCRIPTION
- Added and tested logic for STM32->Jetson communication. Please check out the protocol documents at this URL: https://github.com/illini-robomaster/iRM_Vision_2023/blob/dev/docs/comm_protocol.md
- Changes on the vision side can be found at this URL: https://github.com/illini-robomaster/iRM_Vision_2023/pull/4/files
- Tested communication using Macbook + USB to type A and type C board.

Testing instruction
```
make flash-example_minipc_typeC

# go to vision code
git checkout dev
python3 Communication/communicator.py
```

The type C board LED should start as blue. After python prints 'sending test completed', the LED should turn green. Finally, the python listener should print 'success' before 'packet receiving test complete'