### PR TITLE
Add support to multiple motors for M4310 TransmitOutput() and remove self-pointing params

### DIFF
--- a/examples/motor/m4310_mit.cc
+++ b/examples/motor/m4310_mit.cc
@@ -48,6 +48,9 @@ void RM_RTOS_Init() {
 void RM_RTOS_Default_Task(const void* args) {
   /* press reset if no response */
   UNUSED(args);
+
+  control::Motor4310* motors[] = {motor};
+
   while(dbus->swr != remote::DOWN){}  // flip swr to start
 
   /* Use SetZeroPos if you want to set current motor position as zero position. If uncommented, the
@@ -69,7 +72,7 @@ void RM_RTOS_Default_Task(const void* args) {
     print("Vel Set: %f  Pos Set: %f\n", vel, pos);
 
     motor->SetOutput(pos, vel, 30, 0.5, 0);
-    motor->TransmitOutput(motor);
+    control::Motor4310::TransmitOutput(motors, 1);
     osDelay(10);
   }
 }

--- a/examples/motor/m4310_mit.cc
+++ b/examples/motor/m4310_mit.cc
@@ -52,8 +52,8 @@ void RM_RTOS_Default_Task(const void* args) {
 
   /* Use SetZeroPos if you want to set current motor position as zero position. If uncommented, the
    * zero position is the zero position set before */
-  motor->SetZeroPos(motor);
-  motor->MotorEnable(motor);
+  motor->SetZeroPos();
+  motor->MotorEnable();
 
   float pos = 0;
   float min_pos = -PI/8;

--- a/examples/motor/m4310_pos_vel.cc
+++ b/examples/motor/m4310_pos_vel.cc
@@ -47,6 +47,9 @@ void RM_RTOS_Init() {
 void RM_RTOS_Default_Task(const void* args) {
   /* press reset if no response */
   UNUSED(args);
+
+  control::Motor4310* motors[] = {motor};
+
   while(dbus->swr != remote::DOWN){}  // flip swr to start
 
   /* Use SetZeroPos if you want to set current motor position as zero position. If uncommented, the
@@ -66,7 +69,7 @@ void RM_RTOS_Default_Task(const void* args) {
     print("Vel Set: %f  Pos Set: %f\n", vel, pos);
 
     motor->SetOutput(pos, vel);
-    motor->TransmitOutput(motor);
+    control::Motor4310::TransmitOutput(motors, 1);
     osDelay(10);
   }
 }

--- a/examples/motor/m4310_pos_vel.cc
+++ b/examples/motor/m4310_pos_vel.cc
@@ -51,8 +51,8 @@ void RM_RTOS_Default_Task(const void* args) {
 
   /* Use SetZeroPos if you want to set current motor position as zero position. If uncommented, the
    * zero position is the zero position set before */
-  motor->SetZeroPos(motor);
-  motor->MotorEnable(motor);
+  motor->SetZeroPos();
+  motor->MotorEnable();
 
   float pos = 0;
   while (true) {

--- a/examples/motor/m4310_vel.cc
+++ b/examples/motor/m4310_vel.cc
@@ -51,8 +51,8 @@ void RM_RTOS_Default_Task(const void* args) {
 
   /* Use SetZeroPos if you want to set current motor position as zero position. If uncommented, the
    * zero position is the zero position set before */
-  motor->SetZeroPos(motor);
-  motor->MotorEnable(motor);
+  motor->SetZeroPos();
+  motor->MotorEnable();
 
   while (true) {
     float vel;

--- a/examples/motor/m4310_vel.cc
+++ b/examples/motor/m4310_vel.cc
@@ -47,6 +47,9 @@ void RM_RTOS_Init() {
 void RM_RTOS_Default_Task(const void* args) {
   /* press reset if no response */
   UNUSED(args);
+
+  control::Motor4310* motors[] = {motor};
+
   while(dbus->swr != remote::DOWN){}  // flip swr to start
 
   /* Use SetZeroPos if you want to set current motor position as zero position. If uncommented, the
@@ -63,7 +66,7 @@ void RM_RTOS_Default_Task(const void* args) {
     print("Vel: %f \n", vel);
 
     motor->SetOutput(vel);
-    motor->TransmitOutput(motor);
+    control::Motor4310::TransmitOutput(motors, 1);
     osDelay(10);
   }
 }

--- a/shared/libraries/motor.cc
+++ b/shared/libraries/motor.cc
@@ -616,7 +616,7 @@ Motor4310::Motor4310(bsp::CAN* can, uint16_t rx_id, uint16_t tx_id, mode_t mode)
   }
 }
 
-void Motor4310::MotorEnable(Motor4310* motor) {
+void Motor4310::MotorEnable() {
   uint8_t data[8] = {0};
   data[0] = 0xff;
   data[1] = 0xff;
@@ -626,10 +626,10 @@ void Motor4310::MotorEnable(Motor4310* motor) {
   data[5] = 0xff;
   data[6] = 0xff;
   data[7] = 0xfc;
-  motor->can_->Transmit(motor->tx_id_actual_, data, 8);
+  this->can_->Transmit(this->tx_id_actual_, data, 8);
 }
 
-void Motor4310::MotorDisable(control::Motor4310* motor) {
+void Motor4310::MotorDisable() {
   uint8_t data[8] = {0};
   data[0] = 0xff;
   data[1] = 0xff;
@@ -639,10 +639,10 @@ void Motor4310::MotorDisable(control::Motor4310* motor) {
   data[5] = 0xff;
   data[6] = 0xff;
   data[7] = 0xfd;
-  motor->can_->Transmit(motor->tx_id_actual_, data, 8);
+  this->can_->Transmit(this->tx_id_actual_, data, 8);
 }
 
-void Motor4310::SetZeroPos(control::Motor4310* motor) {
+void Motor4310::SetZeroPos() {
   uint8_t data[8] = {0};
   data[0] = 0xff;
   data[1] = 0xff;
@@ -652,7 +652,7 @@ void Motor4310::SetZeroPos(control::Motor4310* motor) {
   data[5] = 0xff;
   data[6] = 0xff;
   data[7] = 0xfe;
-  motor->can_->Transmit(motor->tx_id_actual_, data, 8);
+  this->can_->Transmit(this->tx_id_actual_, data, 8);
 }
 
 void Motor4310::SetOutput(float position, float velocity, float kp, float kd, float torque) {

--- a/shared/libraries/motor.cc
+++ b/shared/libraries/motor.cc
@@ -672,49 +672,53 @@ void Motor4310::SetOutput(float velocity) {
   vel_set_ = velocity;
 }
 
-void Motor4310::TransmitOutput(Motor4310* motor) {
-  uint8_t data[8] = {0};
-  uint16_t kp_tmp, kd_tmp, pos_tmp, vel_tmp, torque_tmp;
+mode_t Motor4310::GetMode() const {
+  return mode_;
+}
 
-  if (mode_ == MIT) {
-    // converting float to unsigned int before transmitting
-    kp_tmp = float_to_uint(kp_set_, KP_MIN, KP_MAX, 12);
-    kd_tmp = float_to_uint(kd_set_, KD_MIN, KD_MAX, 12);
-    pos_tmp = float_to_uint(pos_set_, P_MIN, P_MAX, 16);
-    vel_tmp = float_to_uint(vel_set_, V_MIN, V_MAX, 12);
-    torque_tmp = float_to_uint(torque_set_, T_MIN, T_MAX, 12);
-    data[0] = pos_tmp >> 8;
-    data[1] = pos_tmp & 0x00ff;
-    data[2] = (vel_tmp >> 4) & 0x00ff;
-    data[3] = ((vel_tmp & 0x000f) << 4) | ((kp_tmp >> 8) & 0x000f);
-    data[4] = kp_tmp & 0x00ff;
-    data[5] = (kd_tmp >> 4) & 0x00ff;
-    data[6] = ((kd_tmp & 0x000f) << 4) | ((torque_tmp >> 8) & 0x000f);
-    data[7] = torque_tmp & 0x00ff;
-  } else if (mode_ == POS_VEL) {
-    uint8_t *pbuf, *vbuf;
-    pbuf = (uint8_t*)&pos_set_;
-    vbuf = (uint8_t*)&vel_set_;
-    data[0] = *pbuf;
-    data[1] = *(pbuf + 1);
-    data[2] = *(pbuf + 2);
-    data[3] = *(pbuf + 3);
-    data[4] = *vbuf;
-    data[5] = *(vbuf + 1);
-    data[6] = *(vbuf + 2);
-    data[7] = *(vbuf + 3);
-  } else if (mode_ == VEL) {
-    uint8_t* vbuf;
-    vbuf = (uint8_t*)&vel_set_;
-    data[0] = *vbuf;
-    data[1] = *(vbuf + 1);
-    data[2] = *(vbuf + 2);
-    data[3] = *(vbuf + 3);
-  } else {
-    RM_EXPECT_TRUE(false, "Invalid mode number!");
+void Motor4310::TransmitOutput(Motor4310* motors[], uint8_t num_motors) {
+  for (uint8_t i = 0; i < num_motors; ++i) {
+    uint8_t data[8] = {0};
+    uint16_t kp_tmp, kd_tmp, pos_tmp, vel_tmp, torque_tmp;
+    if (motors[i]->GetMode() == MIT) {
+      // converting float to unsigned int before transmitting
+      kp_tmp = float_to_uint(motors[i]->kp_set_, KP_MIN, KP_MAX, 12);
+      kd_tmp = float_to_uint(motors[i]->kd_set_, KD_MIN, KD_MAX, 12);
+      pos_tmp = float_to_uint(motors[i]->pos_set_, P_MIN, P_MAX, 16);
+      vel_tmp = float_to_uint(motors[i]->vel_set_, V_MIN, V_MAX, 12);
+      torque_tmp = float_to_uint(motors[i]->torque_set_, T_MIN, T_MAX, 12);
+      data[0] = pos_tmp >> 8;
+      data[1] = pos_tmp & 0x00ff;
+      data[2] = (vel_tmp >> 4) & 0x00ff;
+      data[3] = ((vel_tmp & 0x000f) << 4) | ((kp_tmp >> 8) & 0x000f);
+      data[4] = kp_tmp & 0x00ff;
+      data[5] = (kd_tmp >> 4) & 0x00ff;
+      data[6] = ((kd_tmp & 0x000f) << 4) | ((torque_tmp >> 8) & 0x000f);
+      data[7] = torque_tmp & 0x00ff;
+    } else if (motors[i]->GetMode() == POS_VEL) {
+      uint8_t *pbuf, *vbuf;
+      pbuf = (uint8_t*)&motors[i]->pos_set_;
+      vbuf = (uint8_t*)&motors[i]->vel_set_;
+      data[0] = *pbuf;
+      data[1] = *(pbuf + 1);
+      data[2] = *(pbuf + 2);
+      data[3] = *(pbuf + 3);
+      data[4] = *vbuf;
+      data[5] = *(vbuf + 1);
+      data[6] = *(vbuf + 2);
+      data[7] = *(vbuf + 3);
+    } else if (motors[i]->GetMode() == VEL) {
+      uint8_t* vbuf;
+      vbuf = (uint8_t*)&motors[i]->vel_set_;
+      data[0] = *vbuf;
+      data[1] = *(vbuf + 1);
+      data[2] = *(vbuf + 2);
+      data[3] = *(vbuf + 3);
+    } else {
+      RM_EXPECT_TRUE(false, "Invalid mode number!");
+    }
+    motors[i]->can_->Transmit(motors[i]->tx_id_actual_, data, 8);
   }
-  motor->can_->Transmit(motor->tx_id_actual_, data, 8);
-  connection_flag_ = true;  // temp
 }
 
 void Motor4310::UpdateData(const uint8_t data[]) {

--- a/shared/libraries/motor.cc
+++ b/shared/libraries/motor.cc
@@ -680,6 +680,7 @@ void Motor4310::TransmitOutput(Motor4310* motors[], uint8_t num_motors) {
   for (uint8_t i = 0; i < num_motors; ++i) {
     uint8_t data[8] = {0};
     uint16_t kp_tmp, kd_tmp, pos_tmp, vel_tmp, torque_tmp;
+
     if (motors[i]->GetMode() == MIT) {
       // converting float to unsigned int before transmitting
       kp_tmp = float_to_uint(motors[i]->kp_set_, KP_MIN, KP_MAX, 12);
@@ -717,6 +718,7 @@ void Motor4310::TransmitOutput(Motor4310* motors[], uint8_t num_motors) {
     } else {
       RM_EXPECT_TRUE(false, "Invalid mode number!");
     }
+    
     motors[i]->can_->Transmit(motors[i]->tx_id_actual_, data, 8);
   }
 }

--- a/shared/libraries/motor.h
+++ b/shared/libraries/motor.h
@@ -703,7 +703,7 @@ class Motor4310 {
    *                1: position-velocity
    *                2: velocity
    */
-  void TransmitOutput(control::Motor4310* motor);
+  static void TransmitOutput(control::Motor4310* motors[], uint8_t num_motors);
 
   /* implements data printout */
   void PrintData();
@@ -770,6 +770,8 @@ class Motor4310 {
    * @return motor torque
    */
   float GetTorque() const;
+
+  mode_t GetMode() const;
 
   volatile bool connection_flag_ = false;
 

--- a/shared/libraries/motor.h
+++ b/shared/libraries/motor.h
@@ -687,13 +687,13 @@ class Motor4310 {
   void UpdateData(const uint8_t data[]);
 
   /* enable m4310; MUST be called after motor is powered up, otherwise SetOutput commands are ignored */
-  void MotorEnable(Motor4310* motor);
+  void MotorEnable();
   /* disable m4310 */
-  void MotorDisable(Motor4310* motor);
+  void MotorDisable();
 
   /** sets current motor position as zero position (when motor is powered). M4310 remembers this position
    * when powered off. */
-  void SetZeroPos(Motor4310* motor);
+  void SetZeroPos();
 
   /**
    * implements transmit output specifically for 4310

--- a/vehicles/Steering/gimbal.cc
+++ b/vehicles/Steering/gimbal.cc
@@ -156,6 +156,7 @@ void gimbalTask(void* arg) {
   UNUSED(arg);
 
   control::MotorCANBase* motors_can1_gimbal[] = {yaw_motor};
+  control::Motor4310* motors_can1_pitch[] = {pitch_motor};
 
   print("Wait for beginning signal...\r\n");
   RGB->Display(display::color_red);
@@ -187,7 +188,7 @@ void gimbalTask(void* arg) {
     control::MotorCANBase::TransmitOutput(motors_can1_gimbal, 1);
     tmp_pos += START_PITCH_POS / SOFT_START_CONSTANT;  // increase position gradually
     pitch_motor->SetOutput(tmp_pos, 1, 115, 0.5, 0);
-    pitch_motor->TransmitOutput(pitch_motor);
+    control::Motor4310::TransmitOutput(motors_can1_pitch, 1);
     osDelay(GIMBAL_TASK_DELAY);
   }
 
@@ -204,7 +205,7 @@ void gimbalTask(void* arg) {
     gimbal->Update();
     control::MotorCANBase::TransmitOutput(motors_can1_gimbal, 1);
     pitch_motor->SetOutput(tmp_pos, 1, 115, 0.5, 0);
-    pitch_motor->TransmitOutput(pitch_motor);
+    control::Motor4310::TransmitOutput(motors_can1_pitch, 1);
     osDelay(GIMBAL_TASK_DELAY);
   }
 
@@ -251,7 +252,7 @@ void gimbalTask(void* arg) {
       for (int j = 0; j < SOFT_START_CONSTANT; j++){
         tmp_pos += START_PITCH_POS / SOFT_START_CONSTANT;  // increase position gradually
         pitch_motor->SetOutput(tmp_pos, 1, 115, 0.5, 0);
-        pitch_motor->TransmitOutput(pitch_motor);
+        control::Motor4310::TransmitOutput(motors_can1_pitch, 1);
         osDelay(GIMBAL_TASK_DELAY);
       }
       pitch_pos = tmp_pos;
@@ -263,7 +264,7 @@ void gimbalTask(void* arg) {
 
     pitch_motor->SetOutput(pitch_pos, pitch_vel, 115, 0.5, 0);
     control::MotorCANBase::TransmitOutput(motors_can1_gimbal, 1);
-    pitch_motor->TransmitOutput(pitch_motor);
+    control::Motor4310::TransmitOutput(motors_can1_pitch, 1);
     osDelay(GIMBAL_TASK_DELAY);
   }
 }
@@ -717,6 +718,7 @@ void KillAll() {
 
   control::MotorCANBase* motors_can2_gimbal[] = {yaw_motor};
   control::MotorCANBase* motors_can1_shooter[] = {sl_motor, sr_motor, ld_motor};
+  control::Motor4310* motors_can1_pitch[] = {pitch_motor};
 
   RGB->Display(display::color_blue);
   laser->Off();
@@ -741,7 +743,7 @@ void KillAll() {
     for (int j = 0; j < SOFT_KILL_CONSTANT; j++){
       tmp_pos -= START_PITCH_POS / SOFT_KILL_CONSTANT;  // decrease position gradually
       pitch_motor->SetOutput(tmp_pos, 1, 115, 0.5, 0);
-      pitch_motor->TransmitOutput(pitch_motor);
+      control::Motor4310::TransmitOutput(motors_can1_pitch, 1);
       osDelay(GIMBAL_TASK_DELAY);
     }
 

--- a/vehicles/Steering/gimbal.cc
+++ b/vehicles/Steering/gimbal.cc
@@ -175,8 +175,8 @@ void gimbalTask(void* arg) {
     ++i;
   }
 
-  pitch_motor->SetZeroPos(pitch_motor);
-  pitch_motor->MotorEnable(pitch_motor);
+  pitch_motor->SetZeroPos();
+  pitch_motor->MotorEnable();
   osDelay(GIMBAL_TASK_DELAY);
 
   // 4310 soft start
@@ -732,7 +732,7 @@ void KillAll() {
       Dead = false;
       RGB->Display(display::color_green);
       laser->On();
-      pitch_motor->MotorEnable(pitch_motor);
+      pitch_motor->MotorEnable();
       break;
     }
 
@@ -746,7 +746,7 @@ void KillAll() {
     }
 
     pitch_reset = true;
-    pitch_motor->MotorDisable(pitch_motor);
+    pitch_motor->MotorDisable();
 
     yaw_motor->SetOutput(0);
     control::MotorCANBase::TransmitOutput(motors_can2_gimbal, 1);


### PR DESCRIPTION
- Add support to multiple motors for M4310 TransmitOutput(), see #49 
- Remove m4310 pointers in `SetZeroPos()` `MotorEnable()` and `MotorDisable()` parameters
- Change downstream examples and vehicles accordingly.