### PR TITLE
4310 sudden movement bug fix

### DIFF
--- a/shared/libraries/motor.h
+++ b/shared/libraries/motor.h
@@ -732,6 +732,8 @@ class Motor4310 {
    */
   Motor4310(bsp::CAN* can, uint16_t rx_id, uint16_t tx_id, mode_t mode);
 
+  Motor4310(bsp::CAN* can, uint16_t rx_id, uint16_t tx_id, mode_t mode, float P_MAX);
+
   /* implements data update callback */
   void UpdateData(const uint8_t data[]);
 
@@ -865,8 +867,8 @@ class Motor4310 {
   constexpr static float KD_MIN = 0;
   constexpr static float KD_MAX = 5;
   // position
-  constexpr static float P_MIN = -PI;
-  constexpr static float P_MAX = PI;
+  float P_MIN = -PI;
+  float P_MAX = PI;
   // velocity
   constexpr static float V_MIN = -45;
   constexpr static float V_MAX = 45;

--- a/shared/libraries/utils.cc
+++ b/shared/libraries/utils.cc
@@ -66,8 +66,13 @@ uint16_t float_to_uint(float x, float x_min, float x_max, int bits) {
   return (uint16_t) ((x-offset) * ((float)((1<<bits)-1))/span);
 }
 
+// WARNING: this does not produce the correct result when bits = 16
+// e.g. x_min = -PI and x_max = PI, the result is from -2PI to 0 instead if bits = 16
+// probably has to do with int is 16bit and when the bits param is 16
+
 float uint_to_float(int x_int, float x_min, float x_max, int bits) {
   float span = x_max - x_min;
   float offset = x_min;
-  return ((float)x_int) * span / ((float)((1 << bits) - 1)) + offset;
+  int32_t x_int_longer = 0x0000FFFF & x_int; // zero extend 16 bit to 32 bit
+  return ((float)x_int_longer) * span / ((float)((1 << bits) - 1)) + offset;
 }


### PR DESCRIPTION
1. Fix the bug for 4310 position read.
Originally, the position read by 4310 is between -2pi~0, but the command that 4310 receives is from -pi~pi, so if we set 4310 to its current position read, it's possible to see that 4310 will suddenly rotation one full rotation. This is probably because the position data is 16 bits and we are using 16-bit int data type in the code. 
WARNING: This commit only fixes this problem by wrapping the angle received between -P_MAX and P_MAX, and does not try to fix the issue from the basic level.

2. Allow change in 4310 position feedback range.
Originally, 4310 feedback range is a constant (-PI~PI). But actually, the range can be changed using dm's PC software. So now there's a second constructor for 4310 motor that allows customized position feedback range.